### PR TITLE
Added optional buffered response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 reverse_proxy_plug-*.tar
 
+# Vim swap files
+*.sw*

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -152,7 +152,7 @@ defmodule ReverseProxyPlug do
   defp get_client_opts(:chunked, opts) do
     opts
     |> Keyword.put_new(:timeout, :infinity)
-    |> Keyword.put_new(:timeout, :infinity)
+    |> Keyword.put_new(:recv_timeout, :infinity)
     |> Keyword.put_new(:stream_to, self())
   end
 

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -27,7 +27,7 @@ defmodule ReverseProxyPlug do
       |> Keyword.merge(upstream_parts)
       |> Keyword.put_new(:client, @http_client)
 
-    retreive(conn, opts)
+    retrieve(conn, opts)
   end
 
   defp keyword_rename(keywords, old_key, new_key),
@@ -36,7 +36,7 @@ defmodule ReverseProxyPlug do
       |> Keyword.put(new_key, keywords[old_key])
       |> Keyword.delete(old_key)
 
-  defp retreive(conn, options) do
+  defp retrieve(conn, options) do
     {method, url, body, headers} = prepare_request(conn, options)
 
     options[:client].request(
@@ -113,6 +113,7 @@ defmodule ReverseProxyPlug do
 
   defp prepare_request(conn, options) do
     conn =
+      # With HTTP/2 `transfer-encoding` shouldn't be included.
       conn
       |> Conn.delete_req_header("transfer-encoding")
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule ReverseProxyPlug.MixProject do
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),
-      package: package(),
+      package: package()
     ]
   end
 

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -18,7 +18,7 @@ defmodule ReverseProxyTest do
       end)
 
       send(self(), %HTTPoison.AsyncEnd{})
-      nil
+      {:ok, nil}
     end
   end
 


### PR DESCRIPTION
As mentioned in #1, I couldn't find a way to buffer responses with `ReverseProxyPlug` because it always sends chunks back to the client immediately. This behavior prevents your from processing responses (using `Plug.Conn.register_before_send`) from the upstream.

```elixir
conn
|> register_before_send(&process_response/1)
|> ReverseProxyPlug.call(opts)
```

By default, when `process_response` is called, the response was already sent back to the client.

I made a slight modification introducing two new options to the plug: `transfer` and `client_options`. The former specifies whether the response should be chunked (default), while the latter defines the options to pass the HTTP Client (HTTPoison).

If a `transfer` option value different from `:chunked` is passed to `ReverseProxyPlug.call/2`, it doesn't use `stream_response/1`, but wait for the response before sending it back to the client.

