### PR TITLE
remove test warning

### DIFF
--- a/test/reverse_proxy_plug_buffer_test.exs
+++ b/test/reverse_proxy_plug_buffer_test.exs
@@ -26,7 +26,7 @@ defmodule ReverseProxyBufferTest do
     {"cache-control", "max-age=3600"}
   ]
 
-  defp get_buffer_responder(status \\ 200, headers \\ [], body \\ "Success") do
+  defp get_buffer_responder(status, headers, body \\ "Success") do
     fn _method, _url, _body, _headers, _options ->
       {:ok, %HTTPoison.Response{body: body, headers: headers, status_code: status}}
     end


### PR DESCRIPTION
It was
```
warning: the first 2 default arguments in get_buffer_responder/3 are never used
  test/reverse_proxy_plug_buffer_test.exs:29
```