### PR TITLE
Append params to the body of the request

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -209,7 +209,8 @@ defmodule ReverseProxyPlug do
   def read_body(conn) do
     case Conn.read_body(conn) do
       {:ok, body, %{params: params}} when is_map(params) and map_size(params) > 0 ->
-        body <> "&" <> Conn.Query.encode(params)
+        conn = Plug.Conn.fetch_query_params(conn)
+        body <> "&" <> Conn.Query.encode(conn.params)
 
       {:ok, body, _conn} ->
         body

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -206,8 +206,11 @@ defmodule ReverseProxyPlug do
     |> Enum.reject(fn {header, _} -> Enum.member?(hop_by_hop_headers, header) end)
   end
 
-  defp read_body(conn) do
+  def read_body(conn) do
     case Conn.read_body(conn) do
+      {:ok, body, %{params: params}} when is_map(params) and map_size(params) > 0 ->
+        body <> "&" <> Conn.Query.encode(params)
+
       {:ok, body, _conn} ->
         body
 

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -121,6 +121,12 @@ defmodule ReverseProxyPlugTest do
            "deletes the content-length header"
   end
 
+  test "adds params to the request's body on post" do
+    body = ReverseProxyPlug.read_body(conn(:post, "/users", %{"user" => %{"name" => "Jane Doe"}}))
+
+    assert body =~ "user[name]=Jane+Doe"
+  end
+
   test_stream_and_buffer "removes hop-by-hop headers before forwarding request" do
     %{opts: opts, get_responder: get_responder} = test_reuse_opts
 

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -121,10 +121,25 @@ defmodule ReverseProxyPlugTest do
            "deletes the content-length header"
   end
 
-  test "adds params to the request's body on post" do
+  test "appends params to the request's body" do
     body = ReverseProxyPlug.read_body(conn(:post, "/users", %{"user" => %{"name" => "Jane Doe"}}))
 
-    assert body =~ "user[name]=Jane+Doe"
+    assert body == "--plug_conn_test--&user[name]=Jane+Doe"
+  end
+
+  test "appends params and query string params to the request's body" do
+    body =
+      ReverseProxyPlug.read_body(
+        conn(:post, "/users?type=customer", %{"user" => %{"name" => "Jane Doe"}})
+      )
+
+    assert body == "--plug_conn_test--&type=customer&user[name]=Jane+Doe"
+  end
+
+  test "does not append `&` to the reqeust's body if params are not provide" do
+    body = ReverseProxyPlug.read_body(conn(:post, "/users", %{}))
+
+    refute body =~ "&"
   end
 
   test_stream_and_buffer "removes hop-by-hop headers before forwarding request" do


### PR DESCRIPTION
Append params to the body of the request if present. Allow submit of forms and nested forms (e.g. rails' nested forms). 