### PR TITLE
Add raw body check to allow reverse proxy to work with Phoenix

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -206,8 +206,11 @@ defmodule ReverseProxyPlug do
     |> Enum.reject(fn {header, _} -> Enum.member?(hop_by_hop_headers, header) end)
   end
 
-  defp read_body(conn) do
+  def read_body(conn) do
     case Conn.read_body(conn) do
+      {:ok, "", %{assigns: %{raw_body: raw_body}}} ->
+        raw_body
+
       {:ok, body, _conn} ->
         body
 

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -121,6 +121,22 @@ defmodule ReverseProxyPlugTest do
            "deletes the content-length header"
   end
 
+  test "uses raw_body from assigns if body empty and raw_body present" do
+    raw_body = "name=Jane"
+    conn = conn(:post, "/users", nil)
+    conn = update_in(conn.assigns[:raw_body], fn _ -> raw_body end)
+
+    assert ReverseProxyPlug.read_body(conn) == raw_body
+  end
+
+  test "uses body when not empty even if raw_body provided" do
+    raw_body = "name=Jane"
+    conn = conn(:post, "/users", "not raw body")
+    conn = update_in(conn.assigns[:raw_body], fn _ -> raw_body end)
+
+    assert ReverseProxyPlug.read_body(conn) == "not raw body"
+  end
+
   test_stream_and_buffer "removes hop-by-hop headers before forwarding request" do
     %{opts: opts, get_responder: get_responder} = test_reuse_opts
 


### PR DESCRIPTION
**Description**
Because Phoenix reads the `raw body` and does not cache it if you used `reverse_proxy_plug` for post request  `Plug.Conn.read_Body(conn)` return `""` because already bean consumed by Phoenix.
In this [issue](https://github.com/phoenixframework/phoenix/issues/459) are few suggestions and one extension of Plug to allow you to cache the `raw body` and use it from `assigns.conn[:raw_body]`. The change simply adds condition to use that option with reverse proxy.