### PR TITLE
add client custom headers...

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -153,6 +153,13 @@ defmodule ReverseProxyPlug do
     headers =
       conn.req_headers
       |> normalize_headers
+      
+    headers =
+    if is_list(options[:client_headers]),
+        do:
+        Map.merge(Enum.into(headers, %{}), Enum.into(options[:client_headers], %{}))
+        |> Map.to_list,
+        else: headers
 
     headers =
       if options[:preserve_host_header],


### PR DESCRIPTION
if I'm right it is expected feature for customise Headers for upstream... it is may be useful when Upstream service Await some signature at Header (Hasura for example).... 

forward("/url", ReverseProxyPlug, upstream: "http://upstream.service:port", client_headers: [{"X-Custom-Header", "custom_value"}])