### PR TITLE
Fixed HTTPS proxy with non standard port

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -258,4 +258,8 @@ defmodule ReverseProxyPlug do
   defp host_header_from_url(%URI{host: host, port: port, scheme: "http"}) do
     "#{host}:#{port}"
   end
+
+  defp host_header_from_url(%URI{host: host, port: port, scheme: "https"}) do
+    "#{host}:#{port}"
+  end
 end


### PR DESCRIPTION
The host_header_from_url was throwing a function clause error when using a HTTPS port that is not 443. With this fix I am able to proxy port 4001->4002 (HTTPS->HTTP & HTTPS->HTTPS)

Config used for testing:

```elixir
forward("/", to: ReverseProxyPlug,
  upstream: "https://localhost:4002",
  response_mode: :buffer,
  client_options: [hackney: [
    {:ssl_options, [{:cacertfile, "priv/ssl/cacert.pem"}]}
  ]])
```