### PR TITLE
fail when missing upstream keyword opt because it's required

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -12,7 +12,7 @@ defmodule ReverseProxyPlug do
   def init(opts) do
     upstream_parts =
       opts
-      |> Keyword.get(:upstream, "")
+      |> Keyword.fetch!(:upstream)
       |> URI.parse()
       |> Map.to_list()
       |> Enum.filter(fn {_, val} -> val end)

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -137,6 +137,13 @@ defmodule ReverseProxyPlugTest do
     assert ReverseProxyPlug.read_body(conn) == "not raw body"
   end
 
+  test "missing upstream opt results in KeyError" do
+    bad_opts = Keyword.delete(@opts, :upstream)
+    assert_raise KeyError, fn ->
+        ReverseProxyPlug.init(bad_opts)
+    end
+  end
+
   test "calls status callback" do
     ReverseProxyPlug.HTTPClientMock
     |> expect(:request, TestReuse.get_stream_responder(%{status_code: 500}))


### PR DESCRIPTION
This is a nice high utility plug, thanks.

Ran into a silent failure when I had a typo in the :upstream opt, which is actually required (though because of the Plug interface from naming it seems like an opt or option).

This change causes initialization, probably at compile time, to fail if we're missing the :upstream opt.