### PR TITLE
don't add double slashes when it's the root path

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -150,7 +150,7 @@ defmodule ReverseProxyPlug do
     request_path = Path.join(overrides[:request_path] || "/", request_path)
 
     request_path =
-      if String.ends_with?(conn.request_path, "/"),
+      if String.ends_with?(conn.request_path, "/") && !String.ends_with?(request_path, "/"),
         do: request_path <> "/",
         else: request_path
 

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -269,6 +269,23 @@ defmodule ReverseProxyPlugTest do
     assert url == "http://example.com:80/root_path/"
   end
 
+  test_stream_and_buffer "don't add a redundant slash at the end of request path" do
+    %{opts: opts, get_responder: get_responder} = test_reuse_opts
+    opts_with_upstream = Keyword.merge(opts, upstream: "//example.com")
+
+    ReverseProxyPlug.HTTPClientMock
+    |> expect(:request, fn %{url: url} = request ->
+      send(self(), {:url, url})
+      get_responder.(%{}).(request)
+    end)
+
+    conn(:get, "/")
+    |> ReverseProxyPlug.call(ReverseProxyPlug.init(opts_with_upstream))
+
+    assert_receive {:url, url}
+    assert url == "http://example.com:80/"
+  end
+
   test_stream_and_buffer "include the port in the host header when is not the default and preserve_host_header is false in opts" do
     %{opts: opts, get_responder: get_responder} = test_reuse_opts
     opts_with_upstream = Keyword.merge(opts, upstream: "//example-custom-port.com:8081")


### PR DESCRIPTION
There's a bug when the path is just the root, "/"

If upstream is "https://upstream.com":

Current behavior is it will result in "https://upstream.com//"
This patch fixes things so the request will be to "https://upstream.com/"