### PR TITLE
Allow error_callback to be a mfa tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ plug(ReverseProxyPlug,
 )
 ```
 
+Alternatively, a MFA (module, function, argument) tuple can be passed (The error
+will be inserted as last argument):
+
+```elixir
+plug(ReverseProxyPlug,
+  upstream: "example.com",
+  error_callback: {MyErrorHandler, :handle_proxy_error, ["example.com"]}
+)
+```
+
 ### Callbacks for responses in streaming mode
 
 In order to add special handling for responses with particular statuses instead

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ plug(ReverseProxyPlug,
 )
 ```
 
-Alternatively, a MFA (module, function, argument) tuple can be passed (The error
-will be inserted as last argument):
+You can also provide a MFA (module, function, arguments) tuple, to which the
+error will be inserted as the last argument:
 
 ```elixir
 plug(ReverseProxyPlug,

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -56,8 +56,9 @@ defmodule ReverseProxyPlug do
   def response(error, conn, opts) do
     error_callback = opts[:error_callback]
 
-    if error_callback do
-      error_callback.(error)
+    case error_callback do
+      {m, f, a} -> apply(m, f, a ++ [error])
+      fun when is_function(fun) -> fun.(error)
     end
 
     conn

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -59,6 +59,7 @@ defmodule ReverseProxyPlug do
     case error_callback do
       {m, f, a} -> apply(m, f, a ++ [error])
       fun when is_function(fun) -> fun.(error)
+      _ -> :ok
     end
 
     conn

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -59,7 +59,7 @@ defmodule ReverseProxyPlug do
     case error_callback do
       {m, f, a} -> apply(m, f, a ++ [error])
       fun when is_function(fun) -> fun.(error)
-      _ -> :ok
+      nil -> :ok
     end
 
     conn


### PR DESCRIPTION
A modification of https://github.com/tallarium/reverse_proxy_plug/pull/88