### PR TITLE
Fix error_callback as an MFA tuple

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -35,7 +35,7 @@ defmodule ReverseProxyPlug do
     |> Keyword.put_new(:response_mode, :stream)
     |> Keyword.put_new(:status_callbacks, %{})
     |> Keyword.update(:error_callback, nil, fn
-      {m, f, a} -> &apply(m, f, a ++ [&1])
+      {m, f, a} -> {m, f, a}
       fun when is_function(fun) -> fun
     end)
   end
@@ -108,8 +108,10 @@ defmodule ReverseProxyPlug do
   def response(error, conn, opts) do
     error_callback = opts[:error_callback]
 
-    if error_callback do
-      error_callback.(error)
+    case error_callback do
+      {m, f, a} -> apply(m, f, a ++ [error])
+      fun when is_function(fun) -> fun.(error)
+      nil -> :ok
     end
 
     conn

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -429,6 +429,19 @@ defmodule ReverseProxyPlugTest do
     assert timeout_val == httpclient_options[:recv_timeout]
   end
 
+  test "can be initialised as a plug with an MFA error callback" do
+    defmodule Test do
+      use Plug.Builder
+
+      def error_handler(_), do: nil
+
+      plug(ReverseProxyPlug,
+        upstream: "",
+        error_callback: {__MODULE__, :error_handler, []}
+      )
+    end
+  end
+
   defp simulate_upstream_error(conn, reason, opts) do
     error = {:error, %HTTPoison.Error{id: nil, reason: reason}}
 


### PR DESCRIPTION
As uncovered here: https://github.com/tallarium/reverse_proxy_plug/pull/88#issuecomment-734416095.