### PR TITLE
Add support for path params in the upstream path

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -204,7 +204,7 @@ defmodule ReverseProxyPlug do
 
     upstream_path =
       Enum.reduce(conn.path_params, overrides[:request_path], fn {key, value}, path ->
-        String.replace(path, ":#{key}", value)
+        if is_binary(value), do: String.replace(path, ":#{key}", value), else: path
       end)
 
     request_path = Path.join(upstream_path || "/", request_path)

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -201,9 +201,12 @@ defmodule ReverseProxyPlug do
       |> Keyword.merge(Enum.filter(overrides, fn {_, val} -> val end))
 
     request_path = Enum.join(conn.path_info, "/")
-    upstream_path = Enum.reduce(conn.path_params, overrides[:request_path], fn {key, value}, path ->
-      String.replace(path, ":#{key}", value)
-    end)
+
+    upstream_path =
+      Enum.reduce(conn.path_params, overrides[:request_path], fn {key, value}, path ->
+        String.replace(path, ":#{key}", value)
+      end)
+
     request_path = Path.join(upstream_path || "/", request_path)
 
     request_path =

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -201,7 +201,10 @@ defmodule ReverseProxyPlug do
       |> Keyword.merge(Enum.filter(overrides, fn {_, val} -> val end))
 
     request_path = Enum.join(conn.path_info, "/")
-    request_path = Path.join(overrides[:request_path] || "/", request_path)
+    upstream_path = Enum.reduce(conn.path_params, overrides[:request_path], fn {key, value}, path ->
+      String.replace(path, ":#{key}", value)
+    end)
+    request_path = Path.join(upstream_path || "/", request_path)
 
     request_path =
       if String.ends_with?(conn.request_path, "/") && !String.ends_with?(request_path, "/"),

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -260,6 +260,25 @@ defmodule ReverseProxyPlugTest do
     assert_receive({:got_error, ^error})
   end
 
+  test_stream_and_buffer "substitutes path params into upstream path" do
+    %{opts: opts, get_responder: get_responder} = test_reuse_opts
+
+    opts_with_upstream = Keyword.merge(opts, upstream: "//example.com/root_upstream/:id/foo")
+
+    ReverseProxyPlug.HTTPClientMock
+    |> expect(:request, fn %{url: url} = request ->
+      send(self(), {:url, url})
+      get_responder.(%{}).(request)
+    end)
+
+    conn(:get, "/")
+    |> Map.put(:path_params, %{id: "123"})
+    |> ReverseProxyPlug.call(ReverseProxyPlug.init(opts_with_upstream))
+
+    assert_receive {:url, url}
+    assert "http://example.com:80/root_upstream/123/foo/" == url
+  end
+
   test_stream_and_buffer "handles request path and query string" do
     %{opts: opts, get_responder: get_responder} = test_reuse_opts
 


### PR DESCRIPTION
`PlugRouter.forward` supports path params in the incoming path (see: https://hexdocs.pm/plug/Plug.Router.html#forward/2) but ReverseProxyPlug does not currently support using these in the upsteam path. 

This is a fairly simple change but it allows for some simple URL rewriting for specific paths. 

Example
```
# Forward this specific path to a new service that uses a new path structure
forward("/foo/users/:id/profile", to: ReverseProxyPlug, upstream: "new-foo.com/user-profile/:id")

# Forward all other paths to the original service
forward("/foo", to: ReverseProxyPlug, upstream: "foo.com")
```

