### PR TITLE
Add an optional `:if` condition to support runtime feature flags

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -42,6 +42,11 @@ defmodule ReverseProxyPlug do
 
   @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
   def call(conn, opts) do
+    conditional =
+      opts
+      |> Keyword.get(:if)
+      |> get_applied_fn(true)
+
     upstream_parts =
       opts
       |> Keyword.get(:upstream, "")
@@ -52,8 +57,14 @@ defmodule ReverseProxyPlug do
       opts
       |> Keyword.merge(upstream_parts)
 
-    body = read_body(conn)
-    conn |> request(body, opts) |> response(conn, opts)
+    case conditional do
+      true ->
+        body = read_body(conn)
+        conn |> request(body, opts) |> response(conn, opts)
+
+      _ ->
+        conn
+    end
   end
 
   defp get_string(upstream, default \\ "")
@@ -66,10 +77,10 @@ defmodule ReverseProxyPlug do
     default
   end
 
-  defp get_applied_fn(upstream, default \\ "")
+  defp get_applied_fn(func, default \\ "")
 
-  defp get_applied_fn(upstream, _) when is_function(upstream) do
-    upstream.()
+  defp get_applied_fn(func, _) when is_function(func) do
+    func.()
   end
 
   defp get_applied_fn(_, default) do

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -429,6 +429,37 @@ defmodule ReverseProxyPlugTest do
     assert timeout_val == httpclient_options[:recv_timeout]
   end
 
+  test "allow plug to be skipped with an if conditional function" do
+    opts =
+      @opts
+      |> Keyword.put(:if, fn -> false end)
+
+    conn =
+      conn(:get, "/")
+      |> ReverseProxyPlug.call(ReverseProxyPlug.init(Keyword.merge(opts, response_mode: :buffer)))
+
+    assert conn.status == nil
+    assert conn.resp_body == nil
+    assert conn.state == :unset
+  end
+
+  test "ensure plug is not skipped when the if conditional function passes" do
+    ReverseProxyPlug.HTTPClientMock
+    |> expect(:request, TestReuse.get_buffer_responder(%{}))
+
+    opts =
+      @opts
+      |> Keyword.put(:if, fn -> true end)
+
+    conn =
+      conn(:get, "/")
+      |> ReverseProxyPlug.call(ReverseProxyPlug.init(Keyword.merge(opts, response_mode: :buffer)))
+
+    assert conn.status == 200
+    assert conn.resp_body == "Success"
+    assert conn.state == :set
+  end
+
   test "can be initialised as a plug with an MFA error callback" do
     defmodule Test do
       use Plug.Builder


### PR DESCRIPTION
**Use Case:** 
I need to be able to toggle some of my forwarding rules at runtime and between environments. 

This adds support for a simple :if function that can be used to enabled or disable the reverse proxy plug. 

Example
```
forward "/foo", ReverseProxyPlug, upstream: "//example.com/foo", if: &Settings.foo_enabled/0
```