### PR TITLE
When raw_body is provided always use it.

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -287,11 +287,10 @@ defmodule ReverseProxyPlug do
     |> Enum.reject(fn {header, _} -> Enum.member?(hop_by_hop_headers, header) end)
   end
 
+  def read_body(%{assigns: %{raw_body: raw_body}}), do: raw_body
+
   def read_body(conn) do
     case Conn.read_body(conn) do
-      {:ok, "", %{assigns: %{raw_body: raw_body}}} ->
-        raw_body
-
       {:ok, body, _conn} ->
         body
 

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -129,12 +129,12 @@ defmodule ReverseProxyPlugTest do
     assert ReverseProxyPlug.read_body(conn) == raw_body
   end
 
-  test "uses body when not empty even if raw_body provided" do
+  test "ignores body when not empty when raw_body is provided" do
     raw_body = "name=Jane"
     conn = conn(:post, "/users", "not raw body")
     conn = update_in(conn.assigns[:raw_body], fn _ -> raw_body end)
 
-    assert ReverseProxyPlug.read_body(conn) == "not raw body"
+    refute ReverseProxyPlug.read_body(conn) == "not raw body"
   end
 
   test "missing upstream opt results in KeyError" do


### PR DESCRIPTION
According to Plug.Conn docs body cannot be fetched multiple times,
so if we have a raw_body is reasonable that someone already fetched it.
In this case we *must* avoid reading it again, because it can stall the connection
since Plug adapter will wait until timeout for a never arriving additional body data.

Also docs explicitly states that if raw_body is present is always used,
so let's enforce such case.