### PR TITLE
Handle x-forwarded-for headers

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -267,6 +267,7 @@ defmodule ReverseProxyPlug do
     headers =
       conn.req_headers
       |> normalize_headers
+      |> add_x_fwd_for_header(conn)
 
     headers =
       if options[:preserve_host_header],
@@ -319,6 +320,23 @@ defmodule ReverseProxyPlug do
 
     headers
     |> Enum.reject(fn {header, _} -> Enum.member?(hop_by_hop_headers, header) end)
+  end
+
+  defp add_x_fwd_for_header(headers, conn) do
+    {x_fwd_for, headers} = Enum.split_with(headers, fn {k, _v} -> k == "x-forwarded-for" end)
+
+    remote_ip = conn.remote_ip |> Tuple.to_list() |> Enum.join(".")
+
+    x_forwarded_for =
+      case x_fwd_for do
+        [{"x-forwarded-for", x_fwd_value}] ->
+          "#{x_fwd_value}, #{remote_ip}"
+
+        _ ->
+          remote_ip
+      end
+
+    headers ++ [{"x-forwarded-for", x_forwarded_for}]
   end
 
   defp recycle_cookies(client_opts, conn) do


### PR DESCRIPTION
Also added a helper function for validating request headers.

Resolves #81 