### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # The directory Mix downloads your dependencies sources to.
 /deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
+# Where third-party dependencies like ExDoc output generated docs.
 /doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
@@ -21,6 +21,9 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 reverse_proxy_plug-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
 
 # Vim swap files
 *.sw*

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2018 Tallarium Technologies
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ReverseProxyPlug
 
+[![Module Version](https://img.shields.io/hexpm/v/reverse_proxy_plug.svg)](https://hex.pm/packages/reverse_proxy_plug)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/reverse_proxy_plug/)
+[![Total Download](https://img.shields.io/hexpm/dt/reverse_proxy_plug.svg)](https://hex.pm/packages/reverse_proxy_plug)
+[![License](https://img.shields.io/hexpm/l/reverse_proxy_plug.svg)](https://github.com/tallarium/reverse_proxy_plug/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/tallarium/reverse_proxy_plug.svg)](https://github.com/tallarium/reverse_proxy_plug/commits/master)
+
 A reverse proxy plug for proxying a request to another URL using [HTTPoison](https://github.com/edgurgel/httpoison).
 Perfect when you need to transparently proxy requests to another service but
 also need to have full programmatic control over the outgoing requests.
@@ -180,6 +186,8 @@ asynchronous response parts, respond to the client and return the `Plug.Conn`.
 `:status_callbacks` must only be given when `:response_mode` is `:stream`,
 which is the default.
 
-## License
+## Copyright and License
 
-ReverseProxyPlug is released under the MIT License.
+Copyright (c) 2018 Tallarium Technologies
+
+ReverseProxyPlug is released under the [MIT License](./LICENSE.md).

--- a/mix.exs
+++ b/mix.exs
@@ -1,33 +1,31 @@
 defmodule ReverseProxyPlug.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/tallarium/reverse_proxy_plug"
+  @version "1.3.2"
+
   def project do
     [
       app: :reverse_proxy_plug,
-      version: "1.3.2",
+      version: @version,
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
-      deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      description: description(),
       aliases: aliases(),
+      deps: deps(),
+      docs: docs(),
       package: package()
     ]
   end
 
-  defp description do
-    """
-    An Elixir reverse proxy Plug with HTTP/2, chunked transfer and path
-    proxying support.
-    """
-  end
-
   defp package do
-    %{
+    [
+      description: "An Elixir reverse proxy Plug with HTTP/2, chunked transfer and path " <>
+        "proxying support.",
       maintainers: ["Michał Szewczak", "Sam Nipps", "Matt Whitworth"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/tallarium/reverse_proxy_plug"}
-    }
+    ]
   end
 
   defp aliases do
@@ -43,14 +41,12 @@ defmodule ReverseProxyPlug.MixProject do
   defp elixirc_paths(:test), do: ["test/support", "lib"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger]
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:plug, "~> 1.6"},
@@ -58,7 +54,21 @@ defmodule ReverseProxyPlug.MixProject do
       {:httpoison, "~> 1.2"},
       {:credo, "~> 1.0", only: [:dev, :test]},
       {:mox, "~> 1.0", only: :test},
-      {:ex_doc, "~> 0.19", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "DEVELOPING.md": [title: "Releasing"],
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.