### PR TITLE
Removes transfer-encoding header from responses with non compliant status codes

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -199,10 +199,15 @@ defmodule ReverseProxyPlug do
           end
 
         %HTTPoison.AsyncHeaders{headers: headers} ->
+          additional_headers =
+            if conn.status >= 200 and conn.status != 204,
+              do: [{"transfer-encoding", "chunked"}],
+              else: []
+
           headers
           |> normalize_headers
           |> Enum.reject(fn {header, _} -> header == "content-length" end)
-          |> Enum.concat([{"transfer-encoding", "chunked"}])
+          |> Enum.concat(additional_headers)
           |> Enum.reduce(conn, fn {header, value}, conn ->
             Conn.put_resp_header(conn, header, value)
           end)

--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -152,6 +152,38 @@ defmodule ReverseProxyPlugTest do
            "deletes the content-length header"
   end
 
+  test "does not sets transfer-encoding headers for informational status class" do
+    ReverseProxyPlug.HTTPClientMock
+    |> expect(:request, TestReuse.get_stream_responder(%{status_code: 100}))
+
+    conn =
+      conn(:get, "/")
+      |> ReverseProxyPlug.call(ReverseProxyPlug.init(@opts))
+
+    resp_header_names =
+      conn.resp_headers
+      |> Enum.map(fn {name, _val} -> name end)
+
+    refute "transfer-encoding" in resp_header_names,
+           "deletes the transfer-encoding header if status class is informational"
+  end
+
+  test "does not sets transfer-encoding headers for no content status code" do
+    ReverseProxyPlug.HTTPClientMock
+    |> expect(:request, TestReuse.get_stream_responder(%{status_code: 204}))
+
+    conn =
+      conn(:post, "/", nil)
+      |> ReverseProxyPlug.call(ReverseProxyPlug.init(@opts))
+
+    resp_header_names =
+      conn.resp_headers
+      |> Enum.map(fn {name, _val} -> name end)
+
+    refute "transfer-encoding" in resp_header_names,
+           "deletes the transfer-encoding header if status code is no content"
+  end
+
   test "uses raw_body from assigns if body empty and raw_body present" do
     raw_body = "name=Jane"
     conn = conn(:post, "/users", nil)


### PR DESCRIPTION
Transfer-Encoding header violates RFC 7230:

https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1
> A server MUST NOT send a Transfer-Encoding header field in any response with a status code of 1xx (Informational) or 204 (No Content).

We are having trouble to update our service mesh, because the new version are dropping requests, that are not compliant with the HTTP spec.

And I think this PR also resolves this issue #36 
