### PR TITLE
Optional upstream transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ upstream requests with the same `Host` header as in the original request.
 forward("/foo", to: ReverseProxyPlug, upstream: "//example.com", preserve_host_header: true)
 ```
 
+### Normalize headers for upstream request
+
+An upstream request will downcase all request header names by default (`ReverseProxyPlug.downcase_headers/1`)
+
+You can override this behaviour by passing your own `normalize_headers/1`, which can transform
+a list of headers - a list of `{"header", "value"}` tuples - and return them in the form desired.
+For instance, you may want to drop certain headers in the upstream request, beyond the usual hop-by-hop
+headers.
+
 ### Response mode
 
 `ReverseProxyPlug` supports two response modes:

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -334,8 +334,9 @@ defmodule ReverseProxyPlug do
       "upgrade"
     ]
 
+    # We downcase here, in case a custom :normalize_headers function does not downcase headers
     headers
-    |> Enum.reject(fn {header, _} -> Enum.member?(hop_by_hop_headers, header) end)
+    |> Enum.reject(fn {header, _} -> Enum.member?(hop_by_hop_headers, String.downcase(header)) end)
   end
 
   defp add_x_fwd_for_header(headers, conn) do

--- a/test/support/test_reuse.ex
+++ b/test/support/test_reuse.ex
@@ -52,7 +52,7 @@ defmodule TestReuse do
     end
   end
 
-  defp make_response(%{} = args) do
+  def make_response(%{} = args) do
     %HTTPClient.Response{
       status_code: args[:status_code] || 200,
       headers: args[:headers] || [],


### PR DESCRIPTION
fixes #150

since downcasing headers is not something that intermediate hops necessarily need to do.

`String.downcase`'ing again in `remove_hop_by_hop_headers` is strictly unnecessary, but it would be useful to have some separate header utility functions for common operations like this (and optimize it there)