### PR TITLE
refactor stream response handling to optional callback

### DIFF
--- a/lib/reverse_proxy_plug/http_client.ex
+++ b/lib/reverse_proxy_plug/http_client.ex
@@ -10,4 +10,8 @@ defmodule ReverseProxyPlug.HTTPClient do
                | __MODULE__.AsyncResponse.t()
                | __MODULE__.MaybeRedirect.t()}
               | {:error, error()}
+
+  @callback stream_response(__MODULE__.AsyncResponse.t()) :: Enumerable.t()
+
+  @optional_callbacks stream_response: 1
 end

--- a/test/support/test_reuse.ex
+++ b/test/support/test_reuse.ex
@@ -3,6 +3,7 @@ defmodule TestReuse do
   @default_opts upstream: "example.com", client: ReverseProxyPlug.HTTPClientMock
 
   alias ReverseProxyPlug.HTTPClient
+  alias ReverseProxyPlug.HTTPClient.Adapters.HTTPoison, as: HTTPoisonAdapter
 
   def get_buffer_responder(response_args) do
     fn request ->
@@ -37,6 +38,9 @@ defmodule TestReuse do
           opts: [response_mode: :stream] ++ unquote(@default_opts),
           get_responder: &TestReuse.get_stream_responder/1
         }
+
+        ReverseProxyPlug.HTTPClientMock
+        |> stub(:stream_response, &HTTPoisonAdapter.stream_response/1)
 
         unquote(body)
       end


### PR DESCRIPTION
fixes #148 

and throw an error if the client adapter does not support the response mode configured.