### PR TITLE
ensure adapter module is loaded before proceeding

### DIFF
--- a/test/reverse_proxy_plug_test.exs
+++ b/test/reverse_proxy_plug_test.exs
@@ -36,6 +36,10 @@ defmodule ReverseProxyPlugTest do
 
   setup :verify_on_exit!
 
+  defmodule MyCustomAdapter do
+    # Used for adapter configuration testing
+  end
+
   test "receives buffer response" do
     headers = [{"host", "example.com"}, {"content-length", "42"}]
 
@@ -721,6 +725,22 @@ defmodule ReverseProxyPlugTest do
              )
 
     assert adapter == opts[:client]
+
+    # Raises if the module is invalid
+
+    Application.put_env(
+      :reverse_proxy_plug,
+      :http_client,
+      Nonsense
+    )
+
+    assert_raise ArgumentError, fn ->
+      ReverseProxyPlug.init(
+        upstream: "",
+        error_callback: {__MODULE__, :error_handler, []},
+        response_mode: :buffer
+      )
+    end
   end
 
   test_stream_and_buffer "recycles cookies from connection" do


### PR DESCRIPTION
fixes #193 

After 3476177d1d524abbac73af30c25c701d84d20eba, first released in 2.4.0, we now check for the existence of a function (`stream_response/1`) during module load.

The previous code would have always checked to ensure `HTTPoison` was loaded using `Code.ensure_loaded/1`.

Use `Code.ensure_loaded/1` to ensure that the module is loaded or raise an exception if it cannot be loaded, and rewrite `ensure_http_client` so that it happens in all cases.

(`Code.ensure_loaded!` was first available in 1.12. When the next major version is released, the current case statement will be cleaned up in favour of this)