### PR TITLE
refactor to separate interface for requests with streamed responses

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -106,13 +106,19 @@ defmodule ReverseProxyPlug do
   def request(conn, body, opts) do
     {method, url, headers, client_options} = prepare_request(conn, opts)
 
-    opts[:client].request(%HTTPClient.Request{
+    request = %HTTPClient.Request{
       method: method,
       url: url,
       body: body,
       headers: headers,
       options: client_options
-    })
+    }
+
+    if opts[:response_mode] == :stream do
+      opts[:client].request_stream(request)
+    else
+      opts[:client].request(request)
+    end
   end
 
   def response({:ok, resp}, conn, opts) do
@@ -184,9 +190,8 @@ defmodule ReverseProxyPlug do
     |> Conn.resp(status, body)
   end
 
-  defp process_response(:stream, initial_conn, %HTTPClient.AsyncResponse{} = resp, opts) do
+  defp process_response(:stream, initial_conn, resp, opts) do
     resp
-    |> opts[:client].stream_response()
     |> Enum.reduce_while(initial_conn, fn
       {:status, status}, conn ->
         case Map.fetch(opts[:status_callbacks], status) do
@@ -268,24 +273,12 @@ defmodule ReverseProxyPlug do
     headers = List.keystore(headers, "host", 0, {"host", proxy_req_host})
 
     client_options =
-      options[:response_mode]
-      |> get_client_opts(options[:client_options])
+      options[:client_options]
+      |> Keyword.put_new(:timeout, :infinity)
+      |> Keyword.put_new(:recv_timeout, :infinity)
       |> recycle_cookies(conn)
 
     {method, url, headers, client_options}
-  end
-
-  defp get_client_opts(:stream, opts) do
-    opts
-    |> Keyword.put_new(:timeout, :infinity)
-    |> Keyword.put_new(:recv_timeout, :infinity)
-    |> Keyword.put_new(:stream_to, self())
-  end
-
-  defp get_client_opts(:buffer, opts) do
-    opts
-    |> Keyword.put_new(:timeout, :infinity)
-    |> Keyword.put_new(:recv_timeout, :infinity)
   end
 
   defp send_stream_response_headers(%{status: status} = conn, headers, opts) do
@@ -409,7 +402,7 @@ defmodule ReverseProxyPlug do
 
   defp ensure_response_mode_compatibility(opts) do
     if opts[:response_mode] == :stream and
-         not function_exported?(opts[:client], :stream_response, 1) do
+         not function_exported?(opts[:client], :request_stream, 1) do
       raise ArgumentError,
             "The client adapter does not support streaming responses. Please use :buffer response mode."
     else

--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -104,15 +104,7 @@ defmodule ReverseProxyPlug do
   end
 
   def request(conn, body, opts) do
-    {method, url, headers, client_options} = prepare_request(conn, opts)
-
-    request = %HTTPClient.Request{
-      method: method,
-      url: url,
-      body: body,
-      headers: headers,
-      options: client_options
-    }
+    request = prepare_request(conn, opts, body)
 
     if opts[:response_mode] == :stream do
       opts[:client].request_stream(request)
@@ -242,7 +234,7 @@ defmodule ReverseProxyPlug do
     end
   end
 
-  defp prepare_request(conn, options) do
+  defp prepare_request(conn, options, body) do
     method =
       try do
         conn.method
@@ -278,7 +270,13 @@ defmodule ReverseProxyPlug do
       |> Keyword.put_new(:recv_timeout, :infinity)
       |> recycle_cookies(conn)
 
-    {method, url, headers, client_options}
+    %HTTPClient.Request{
+      method: method,
+      url: url,
+      body: body,
+      headers: headers,
+      options: client_options
+    }
   end
 
   defp send_stream_response_headers(%{status: status} = conn, headers, opts) do

--- a/lib/reverse_proxy_plug/http_client.ex
+++ b/lib/reverse_proxy_plug/http_client.ex
@@ -7,11 +7,10 @@ defmodule ReverseProxyPlug.HTTPClient do
   @callback request(__MODULE__.Request.t()) ::
               {:ok,
                __MODULE__.Response.t()
-               | __MODULE__.AsyncResponse.t()
                | __MODULE__.MaybeRedirect.t()}
               | {:error, error()}
 
-  @callback stream_response(__MODULE__.AsyncResponse.t()) :: Enumerable.t()
+  @callback request_stream(__MODULE__.Request.t()) :: {:ok, Enumerable.t()} | {:error, error()}
 
-  @optional_callbacks stream_response: 1
+  @optional_callbacks request_stream: 1
 end

--- a/lib/reverse_proxy_plug/http_client/async_response.ex
+++ b/lib/reverse_proxy_plug/http_client/async_response.ex
@@ -1,5 +1,0 @@
-defmodule ReverseProxyPlug.HTTPClient.AsyncResponse do
-  @moduledoc "Carries the reference to be used for parsing an asynchronous response"
-  defstruct id: nil
-  @type t :: %__MODULE__{id: reference | nil}
-end

--- a/test/http_client/adapters/httpoison_test.exs
+++ b/test/http_client/adapters/httpoison_test.exs
@@ -4,7 +4,6 @@ defmodule ReverseProxyPlug.HTTPClient.Adapters.HTTPoisonTest do
   alias ReverseProxyPlug.HTTPClient.Adapters.HTTPoison, as: HTTPoisonClient
 
   alias ReverseProxyPlug.HTTPClient.{
-    AsyncResponse,
     Error,
     Request,
     Response
@@ -50,11 +49,11 @@ defmodule ReverseProxyPlug.HTTPClient.Adapters.HTTPoisonTest do
           Plug.Conn.send_resp(conn, 204, "")
         end)
 
-        assert {:ok, %AsyncResponse{id: id}} = HTTPoisonClient.request(req)
+        assert {:ok, %Response{}} = HTTPoisonClient.request(req)
 
-        assert_receive %HTTPoison.AsyncStatus{id: ^id, code: 204}, 1_000
-        assert_receive %HTTPoison.AsyncHeaders{id: ^id, headers: headers}, 1_000
-        assert_receive %HTTPoison.AsyncEnd{id: ^id}, 1_000
+        assert_receive %HTTPoison.AsyncStatus{code: 204}, 1_000
+        assert_receive %HTTPoison.AsyncHeaders{headers: headers}, 1_000
+        assert_receive %HTTPoison.AsyncEnd{}, 1_000
         assert is_list(headers)
       end
 
@@ -94,9 +93,9 @@ defmodule ReverseProxyPlug.HTTPClient.Adapters.HTTPoisonTest do
         Plug.Conn.send_resp(conn, 204, "")
       end)
 
-      assert {:ok, %AsyncResponse{id: id}} = HTTPoisonClient.request(req)
+      assert {:ok, %Response{}} = HTTPoisonClient.request(req)
 
-      assert_receive %HTTPoison.Error{id: ^id, reason: {:closed, :timeout}}, 1_000
+      assert_receive %HTTPoison.Error{reason: {:closed, :timeout}}, 1_000
     end
   end
 end

--- a/test/support/test_reuse.ex
+++ b/test/support/test_reuse.ex
@@ -3,7 +3,6 @@ defmodule TestReuse do
   @default_opts upstream: "example.com", client: ReverseProxyPlug.HTTPClientMock
 
   alias ReverseProxyPlug.HTTPClient
-  alias ReverseProxyPlug.HTTPClient.Adapters.HTTPoison, as: HTTPoisonAdapter
 
   def get_buffer_responder(response_args) do
     fn request ->
@@ -15,19 +14,18 @@ defmodule TestReuse do
     fn request ->
       %{status_code: code, headers: headers, body: body} = make_response(response_args, request)
 
-      send(self(), %HTTPoison.AsyncStatus{code: code})
-      send(self(), %HTTPoison.AsyncHeaders{headers: headers})
+      body_chunks =
+        body
+        |> String.codepoints()
+        |> Enum.chunk_every(body |> String.length() |> div(3))
+        |> Enum.map(&Enum.join/1)
+        |> Enum.map(&{:chunk, &1})
 
-      body
-      |> String.codepoints()
-      |> Enum.chunk_every(body |> String.length() |> div(3))
-      |> Enum.map(&Enum.join/1)
-      |> Enum.each(fn chunk ->
-        send(self(), %HTTPoison.AsyncChunk{chunk: chunk})
-      end)
-
-      send(self(), %HTTPoison.AsyncEnd{})
-      {:ok, %HTTPClient.AsyncResponse{}}
+      {:ok,
+       [
+         {:status, code},
+         {:headers, headers}
+       ] ++ body_chunks}
     end
   end
 
@@ -36,11 +34,9 @@ defmodule TestReuse do
       test unquote(message) <> " (stream)" do
         var!(test_reuse_opts) = %{
           opts: [response_mode: :stream] ++ unquote(@default_opts),
-          get_responder: &TestReuse.get_stream_responder/1
+          get_responder: &TestReuse.get_stream_responder/1,
+          req_function: :request_stream
         }
-
-        ReverseProxyPlug.HTTPClientMock
-        |> stub(:stream_response, &HTTPoisonAdapter.stream_response/1)
 
         unquote(body)
       end
@@ -48,7 +44,8 @@ defmodule TestReuse do
       test unquote(message) <> " (buffer)" do
         var!(test_reuse_opts) = %{
           opts: [response_mode: :buffer] ++ unquote(@default_opts),
-          get_responder: &TestReuse.get_buffer_responder/1
+          get_responder: &TestReuse.get_buffer_responder/1,
+          req_function: :request
         }
 
         unquote(body)


### PR DESCRIPTION
so we can support other adapters which require special options to be provided to the `request` function