### PR TITLE
correct req dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule ReverseProxyPlug.MixProject do
 
   defp deps do
     [
-      {:req, "~> 0.3 or ~> 0.4 or ~> 0.5", optional: true},
+      {:req, "~> 0.3.0 or ~> 0.4.0 or ~> 0.5.0", optional: true},
       {:finch, "~> 0.18", optional: true},
       {:excoveralls, "~> 0.18", only: :test},
       {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
depend on particular minor releases of req pre-1.0, since the interface and behaviour changes