### PR TITLE
fix: remove fixed req task timeout

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.0
-erlang 24.0.1
+elixir 1.18.2
+erlang 27.3.1

--- a/lib/reverse_proxy_plug/http_client/adapters/req.ex
+++ b/lib/reverse_proxy_plug/http_client/adapters/req.ex
@@ -94,13 +94,9 @@ if Code.ensure_loaded?(Req) do
       end
 
       defp async_request(req, parent) do
-        fn ->
-          ret = request(req)
-          send(parent, :eof)
-          ret
-        end
-        |> Task.async()
-        |> Task.await()
+        ret = request(req)
+        send(parent, :eof)
+        ret
       end
 
       defp body_stream do


### PR DESCRIPTION
fixes: https://github.com/tallarium/reverse_proxy_plug/issues/236

Removes the useless `Task` since it's immediately being `await`ed and let's the `Req` timeouts take effect.