### PR TITLE
`preserve_host_header` option omits port number from the original `Host` header

### DIFF
--- a/lib/reverse_proxy_plug.ex
+++ b/lib/reverse_proxy_plug.ex
@@ -255,7 +255,8 @@ defmodule ReverseProxyPlug do
 
     proxy_req_host =
       if options[:preserve_host_header] do
-        conn.host
+        {"host", host} = List.keyfind(conn.req_headers, "host", 0, {"host", conn.host})
+        host
       else
         host_header_from_url(url)
       end


### PR DESCRIPTION
Plug's `conn.host` is not equal to `Host` HTTP header.

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Host), `Host` header contains the host and port number of the server to which the request is being sent.
On the other side, `conn.host` contains only the host.

Even though you enable `preserve_host_header` option, the `Host` header is not preserved currently.
The port number is omitted.

This PR is to fix the problem and preserve original `Host` header intact.