### PR TITLE
Support httpoison 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule ReverseProxyPlug.MixProject do
       {:excoveralls, "~> 0.18", only: :test},
       {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false},
       {:plug, "~> 1.6"},
-      {:httpoison, "~> 1.4 or ~> 2.0", optional: true},
+      {:httpoison, "~> 1.4 or ~> 2.0 or ~> 3.0", optional: true},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:hammox, "~> 0.7", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Adding httpoison 3.0 as an allowed version. This is required because this is the first version that depends on hackney v4, which is the first hackney version that resolves quite a few CVEs.

I also bumped Tesla in the lockfile, so that the lock now contains hackney v4 (to test for any behaviour changes), which revealed a small test failure as httpoison timeouts are now returned as `reason: :timeout` instead of `{:closed, :timeout}`.

Not sure if the lockfile updates are desired, so happy to revert these if wanted.